### PR TITLE
Publish with NO_COLOR=1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33492,6 +33492,13 @@ var import_fs_extra = __toESM(require_lib2());
 async function execWithOutput(command, args, options) {
   let myOutput = "";
   let myError = "";
+  if (options == null ? void 0 : options.env) {
+    for (const [key, val] of Object.entries(process.env)) {
+      if (!(key in options.env) && val) {
+        options.env[key] = val;
+      }
+    }
+  }
   return {
     code: await (0, import_exec.exec)(command, args, {
       listeners: {
@@ -33616,6 +33623,9 @@ async function runPublish({
       tagName
     ],
     {
+      env: {
+        NO_COLOR: "1"
+      },
       cwd
     }
   );

--- a/src/run.ts
+++ b/src/run.ts
@@ -65,6 +65,11 @@ export async function runPublish({
       tagName,
     ],
     {
+      env: {
+        // changesets cli outputs stuff with ASCII colors which can polute the stdout with
+        // color characters and therefore incorrectly parse which packages have been published
+        NO_COLOR: "1",
+      },
       cwd,
     }
   );

--- a/src/run.ts
+++ b/src/run.ts
@@ -82,6 +82,9 @@ export async function runPublish({
 
   let releasedPackages: PublishedPackage[] = [];
 
+  console.log("Changeset publish output:");
+  console.log(changesetPublishOutput.stdout);
+
   for (let line of changesetPublishOutput.stdout.split("\n")) {
     let match = extractPublishedPackages(line);
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -82,9 +82,6 @@ export async function runPublish({
 
   let releasedPackages: PublishedPackage[] = [];
 
-  console.log("Changeset publish output:");
-  console.log(changesetPublishOutput.stdout);
-
   for (let line of changesetPublishOutput.stdout.split("\n")) {
     let match = extractPublishedPackages(line);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,10 +5,23 @@ import fs from "fs-extra";
 export async function execWithOutput(
   command: string,
   args?: string[],
-  options?: { ignoreReturnCode?: boolean; cwd?: string }
+  options?: {
+    ignoreReturnCode?: boolean;
+    cwd?: string;
+    env?: { [key: string]: string };
+  }
 ) {
   let myOutput = "";
   let myError = "";
+
+  // inject the rest of process env vars
+  if (options?.env) {
+    for (const [key, val] of Object.entries(process.env)) {
+      if (!(key in options.env) && val) {
+        options.env[key] = val;
+      }
+    }
+  }
 
   return {
     code: await exec(command, args, {


### PR DESCRIPTION
@changesets/cli@2.27.8 [changed the terminal color renderer](https://github.com/changesets/changesets/pull/1417) which introduced additional ASCII characters to stdout breaking the line parser during publish and therefore not detecting published packages.

This PR disables the colors in the terminal making sure parsing works all the time.

### TODO

- [ ] Dont use fork in shared-config@v1 ([see here](https://github.com/the-guild-org/shared-config/blob/8d19f382a693c8a571418006a80ed17963e7e1e0/.github/workflows/release-snapshot.yml#L80)) after merging this
- [ ] Confirm https://github.com/dotansimha/changesets-action is still working (it relies on parsing the stdout too).